### PR TITLE
Use links for search results and Back to search

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,11 +100,18 @@ ul, ul li {
   margin: 0 auto;
 }
 
+.searchResult a {
+  display: block;
+  padding: 5px 10px;
+  background: #e9e9ed;
+}
+
 .searchResult span {
   position: absolute;
   color: yellow;
-  bottom: 10px;
+  bottom: 7px;
   width: 100%;
+  font-size: 13px;
   text-align: center;
   text-shadow:
     -1px -1px 0 #000,
@@ -122,6 +129,7 @@ ul, ul li {
 img.thumbnail {
   width: 180px;
   height: 101px;
+  display: block;
 }
 
 #selectedItem .back {

--- a/src/App.css
+++ b/src/App.css
@@ -78,9 +78,20 @@ header button {
   height: 30px;
 }
 
-button {
+button,
+.button {
+  display: inline-block;
   border: none;
+  font-size: 14px;
   padding: 4px 10px;
+  background: #e9e9ed;
+  color: black;
+  text-decoration: none;
+}
+
+button:hover,
+.button:hover {
+  background: #d0d0d7;
 }
 
 ul {
@@ -100,16 +111,10 @@ ul, ul li {
   margin: 0 auto;
 }
 
-.searchResult a {
-  display: block;
-  padding: 5px 10px;
-  background: #e9e9ed;
-}
-
 .searchResult span {
   position: absolute;
   color: yellow;
-  bottom: 7px;
+  bottom: 10px;
   width: 100%;
   font-size: 13px;
   text-align: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ function Main ({
         {searchResults.map((doc: SearchResult) => (<li key={doc.id} className="searchResult">
           <Link
             to={`/${encodeURIComponent(doc.season)}/${encodeURIComponent(doc.episode)}/${encodeURIComponent(doc.id)}`}
+            className="button"
             onClick={() => {
               setSelectedItem(doc)
               setCaption(striptags(doc.html))
@@ -97,7 +98,6 @@ function Frame ({
   workerInstance: typeof Worker
 }) {
   const { season, episode, id } = useParams()
-  const navigate = useNavigate()
   const [mosaicData, setMosaicData] = useState('')
   const clearMosaic = async () => {
     setMosaicData('')
@@ -207,10 +207,9 @@ function Frame ({
     return <>Loading...</>
   }
   return <div id="selectedItem">
-    <button onClick={() => {
-      navigate('/')
+    <Link to='/' onClick={() => {
       setSelectedItem(null)
-    }} className="back">Back to search</button>
+    }} className="button back">Back to search</Link>
     <canvas ref={canvasRef}></canvas>
     <img ref={imageRef} alt="" />
     <div id="frameNavigation">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ import {
   useParams,
   Outlet,
   Routes,
-  Route
+  Route,
+  Link
 } from 'react-router-dom'
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -36,7 +37,6 @@ function Main ({
   setCaption: (_: string) => void,
   setSelectedItem: (_: SearchResult) => void,
 }) {
-  const navigate = useNavigate()
   useEffect(() => {
     document.body.style.backgroundImage = searchResults.length > 0
       ? ''
@@ -59,17 +59,18 @@ function Main ({
       }</>
     }
     {ready && searchResults.length > 0 && <div>
-      {/* eslint-disable-next-line */}
       <ul aria-description="Search results">
         {searchResults.map((doc: SearchResult) => (<li key={doc.id} className="searchResult">
-          <button onClick={() => {
-            navigate(`/${encodeURIComponent(doc.season)}/${encodeURIComponent(doc.episode)}/${encodeURIComponent(doc.id)}`)
-            setSelectedItem(doc)
-            setCaption(striptags(doc.html))
-          }}>
+          <Link
+            to={`/${encodeURIComponent(doc.season)}/${encodeURIComponent(doc.episode)}/${encodeURIComponent(doc.id)}`}
+            onClick={() => {
+              setSelectedItem(doc)
+              setCaption(striptags(doc.html))
+            }}
+          >
             <img src={`${process.env.REACT_APP_ASSETS_URL}/${doc.season}x${('' + doc.episode).padStart(2, '0')}/${doc.id}_thumbnail.${process.env.REACT_APP_ASSETS_EXTENSION || 'png'}`} alt="" className="thumbnail" />
             <span>{striptags(doc.html)}</span>
-          </button>
+          </Link>
         </li>))}
       </ul>
     </div>}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,6 @@ function Frame ({
   setSelectedItem,
   next,
   previous,
-  ready,
   caption,
   setCaption,
   workerInstance
@@ -92,7 +91,6 @@ function Frame ({
   setSelectedItem: (_: null) => void,
   next: () => void,
   previous: () => void,
-  ready: boolean,
   caption: string,
   setCaption: (_: string) => void,
   workerInstance: typeof Worker
@@ -399,7 +397,6 @@ function App () {
               setSelectedItem={setSelectedItem}
               next={next}
               previous={previous}
-              ready={ready}
               />} />
             </Route>
         </Routes>


### PR DESCRIPTION
These simple PR makes these things actual link tags, i.e. `<a>`s:

![image](https://user-images.githubusercontent.com/722544/173212232-bf30f0c5-e365-4463-9701-ec85896d9189.png)
![image](https://user-images.githubusercontent.com/722544/173212219-cbba3d9f-b298-4079-9922-4b8ba445c708.png)

Having actual links instead of buttons allows browsers (and crawlers, maybe) to understand the page better, and for example let users to middle-click these links to open them on new tabs :)

I also wanted to change the Previous / Next buttons to be links, but those do some service worker magic that i didn't really want to dig into for now.

Also, i think it'd be nice if these links were simple `<Link to="/something">`, without extra `onClick` logic, such that the current URL dictates the application state, instead of the other way around. But, that's a more ambitious refactor, and i wanted to start super small.

I hope you're cool with this patch. And, if you're interested in the suggestions mentioned above, please let me know :slightly_smiling_face: 