### PR TITLE
Fix back and forth navigation issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,8 @@ function Frame ({
   previous,
   caption,
   setCaption,
-  workerInstance
+  workerInstance,
+  ready
 }: {
   selectedItem: SearchResult | null,
   setSelectedItem: (_: null) => void,
@@ -93,7 +94,8 @@ function Frame ({
   previous: () => void,
   caption: string,
   setCaption: (_: string) => void,
-  workerInstance: typeof Worker
+  workerInstance: typeof Worker,
+  ready: boolean
 }) {
   const { season, episode, id } = useParams()
   const [mosaicData, setMosaicData] = useState('')
@@ -192,16 +194,18 @@ function Frame ({
     })()
   }, [getCurrentFrame])
 
-  if (
-    !selectedItem ||
+  const needsLoading = !selectedItem ||
     selectedItem.season !== parseInt(season || '', 10) ||
     selectedItem.episode !== parseInt(episode || '', 10) ||
-    selectedItem.id !== parseInt(id || '', 10)) {
-    workerInstance?.goToFrame(
-      parseInt(season || '', 10),
-      parseInt(episode || '', 10),
-      parseInt(id || '', 10)
-    )
+    selectedItem.id !== parseInt(id || '', 10)
+
+  useEffect(() => {
+    if (needsLoading && ready) {
+      workerInstance?.goToFrame(season, episode, id)
+    }
+  }, [needsLoading, ready, workerInstance, season, episode, id])
+
+  if (needsLoading) {
     return <>Loading...</>
   }
   return <div id="selectedItem">
@@ -397,6 +401,7 @@ function App () {
               setSelectedItem={setSelectedItem}
               next={next}
               previous={previous}
+              ready={ready}
               />} />
             </Route>
         </Routes>

--- a/src/search.worker.ts
+++ b/src/search.worker.ts
@@ -55,7 +55,7 @@ export async function search (searchCriteria: string) {
   doSearch()
 }
 
-export function randomFrame () {
+export function loadRandomFrame () {
   if (!storedFields || !documentIds) {
     return
   }
@@ -64,12 +64,12 @@ export function randomFrame () {
   if (!storedFields[key]) {
     return
   }
-  global.self.postMessage(['goToFrame', {
+  return {
     id: documentIds[key],
     episode: storedFields[key].episode,
     html: storedFields[key].html,
     season: storedFields[key].season
-  }])
+  }
 }
 
 export function loadFrame (season: string, episode: string, id: string, delta: number = 0) {
@@ -82,17 +82,4 @@ export function loadFrame (season: string, episode: string, id: string, delta: n
     html: storedFields[key].html,
     season: storedFields[key].season
   }
-}
-
-function goToFrame (season: string, episode: string, id: string, delta: number = 0) {
-  if (!documentIds || !storedFields) return
-  global.self.postMessage(['goToFrame', loadFrame(season, episode, id, delta)])
-}
-
-export function nextFrame (season: string, episode: string, id: string) {
-  return goToFrame(season, episode, id, 1)
-}
-
-export function previousFrame (season: string, episode: string, id: string) {
-  return goToFrame(season, episode, id, -1)
 }

--- a/src/search.worker.ts
+++ b/src/search.worker.ts
@@ -72,16 +72,21 @@ export function randomFrame () {
   }])
 }
 
-export function goToFrame (season: string, episode: string, id: string, delta: number = 0) {
+export function loadFrame (season: string, episode: string, id: string, delta: number = 0) {
   if (!documentIds || !storedFields) return
   const currentFrame = `${season}:${episode}:${id}`
   const key = (parseInt(reverseIndex[currentFrame], 10) + delta) + ''
-  global.self.postMessage(['goToFrame', {
+  return {
     id: documentIds[key],
     episode: storedFields[key].episode,
     html: storedFields[key].html,
     season: storedFields[key].season
-  }])
+  }
+}
+
+function goToFrame (season: string, episode: string, id: string, delta: number = 0) {
+  if (!documentIds || !storedFields) return
+  global.self.postMessage(['goToFrame', loadFrame(season, episode, id, delta)])
 }
 
 export function nextFrame (season: string, episode: string, id: string) {


### PR DESCRIPTION
This PR fixes this curious navigation-related bug:

Steps to reproduce:

1. visit [acrossoverepisode.com](https://acrossoverepisode.com)
2. search for something, like "hello"
3. click on some result, like [this frame of bojack on the street](https://acrossoverepisode.com/#/1/11/1302802)
4. click "Back to search"
5. click some some other result, like [this frame of bojack having a great time on stage](https://acrossoverepisode.com/#/6/9/1281426)
6. click the browser's back button 3 times
7. click the browser's forwards button 3 times

Expected behavior:

We should be back at [that last frame](https://acrossoverepisode.com/#/6/9/1281426) we visited.

Actual behavior:

Once we get to the bojack on the street frame, the back button doesn't work, and going forwards doesn't work either. The navigation history gets messed up.

---

The root cause of this is that the `<Frame>` component is triggering some navigation when it's rendered:

https://github.com/seppo0010/acrossoverepisode.com/blob/48f0a4c67e4d57985089ba861e980bb42cbe0254/src/App.tsx#L195-L204

The `worker.goToFrame()` function causes the worker to then send a message to the main page, which in turn triggers a browser navigation:

https://github.com/seppo0010/acrossoverepisode.com/blob/48f0a4c67e4d57985089ba861e980bb42cbe0254/src/App.tsx#L264-L266

This could've been fixed by adding a conditional to check if we're already on that path and not doing the navigation in that case. But, i thought that a better fix would to avoid these navigations on the `<Frame>` component altogether and simplify the logic related to setting the "selected item".

So, this fix ended up being more of a refactor. Instead of having the "selected item" and "caption" state on the parent `<App>` component and passing those down to their children page components, now that state is local to `<Frame>`, as it's the only component that cares about those :)

Also, the `goToFrame` worker->window message was removed altogether, and instead the places that need to load some frame data and do something with that just ask the worker instance for the data and and do what they want to do with it. This simplifies the async woker<->window communication, as we don't need to jump between different messages and places on the code to understand what's going on. Probably a similar approach can be used for searching.

Finally, note that some quirky behaviors related to navigation are still there. Like, if you type "hello" on the search field, you'll note that the `history.length` will have grown by 5, even though we didn't visit any different URL. I'll try to tackle that and add an actual URL for search pages [on a follow-up](https://github.com/epidemian/acrossoverepisode.com/compare/fix-back-and-forth-navigation...search-url) PR :wink: 